### PR TITLE
Change Suggestions to FAQs

### DIFF
--- a/src/components/HeaderNav.jsx
+++ b/src/components/HeaderNav.jsx
@@ -79,7 +79,7 @@ export default function HeaderNav({ onSuggestionClick, suggestionsOpen }) {
           }
         `}
       >
-        {suggestionsOpen ? "Suggestions" : "Chat"}
+        {suggestionsOpen ? "FAQs" : "Chat"}
       </h2>
 
       {suggestionsToggle}


### PR DESCRIPTION
Closes #10 

Very quick & simple change from 'Suggestions' -> 'FAQs' as per Jeanine's request.

Local render:
![image](https://user-images.githubusercontent.com/13087024/104143306-c8caa400-5373-11eb-8cf1-0b7a3374b5e3.png)
