### PR TITLE
Update greeting card logo and title

### DIFF
--- a/src/components/GreetingCard.jsx
+++ b/src/components/GreetingCard.jsx
@@ -2,9 +2,11 @@
 import { css } from "@emotion/react";
 
 export default function GreetingCard() {
-  const titleText = "Welcome to Swanton Chat!";
+  const titleText = "Welcome to Swanton Poppy Chat!";
   const descriptionText = `Ask anything you want to know about the ranch! 
   Check out some commonly asked questions by clicking the question mark above.`;
+  const logoSrc = `/logo512.png`;
+  const logoAltText = `Swanton Poppy Logo`;
 
   const cardStyles = css`
     width: 70%;
@@ -16,7 +18,16 @@ export default function GreetingCard() {
     box-shadow: 0 5px 20px rgba(0, 0, 0, 0.15);
   `;
 
+  const logoStyle = css`
+    padding: 25px;
+    display: block;
+    margin: 0 auto;
+    width: 50%;
+    height: auto;
+  `;
+
   const titleStyle = css`
+    font-size: 20px;
     text-align: center;
   `;
 
@@ -32,6 +43,7 @@ export default function GreetingCard() {
 
   return (
     <div css={cardStyles}>
+      <img css={logoStyle} src={logoSrc} alt={logoAltText}/>
       <h2 css={titleStyle}>{titleText}</h2>
       {description}
     </div>


### PR DESCRIPTION
### Notes
Closes #9 
* Explicitly made "Welcome to Swanton Poppy Chat!" text smaller since 'Chat!" was getting pushed to second line
 * Maybe we could keep the original size but reduce the padding or something? Not sure

### Testing
Local render:
![image](https://user-images.githubusercontent.com/13087024/104343597-fbc68200-54b0-11eb-8575-99e9e11c72e5.png)

